### PR TITLE
[add] seeds:ジャンルの４項目をseedsに追加

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,4 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 Admin.create!(email: 'test@mail.com', password: 'testtest')
-# Admin.create!([{ email: 'test@mail.com' }, { password: 'testtest' }])
+Genre.create!([
+  { name: 'ケーキ' },
+  { name: 'プリン' },
+  { name: '焼き菓子' },
+  { name: 'キャンディ' }
+])


### PR DESCRIPTION
・db/seeds.rb ファイルにケーキ、プリン、焼き菓子、キャンディの4ジャンルのレコードを追加しました

〜以下注意点↓〜

git pullしたあと、rails db:seed をしても(既存のdevelopだと)反映されません。。(_ _;)
調べたところ、以下の記事で解決できました。

Rails db:seed二重登録解除
https://qiita.com/shiroux/items/2a40c821b1c0c0c8aa9b

一度rails db:seedでadminのレコード（メールとパスワード）を作っているので、再びrails db:seedを実行すると、二重登録となってしまうことを防ぐ仕組みがdb:seedにあるようです。

なので、

rails db:migrate:status

でadminのテーブル番号を調べて、

rails db:migrate:drop VERSION=(adminのテーブル番号)
もしくは
rails db:migrate:reset　　※こちらは他のテーブルの内容も消えるので注意

でseedで入れた値を削除

rails db:migrate
rails db:seed

でseedを再反映

これでケーキ、プリン、焼き菓子、キャンディの4ジャンルが初期ジャンルとして入るようになりました！d(￣ ￣)